### PR TITLE
chore: silence Vite 8 plugin deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@types/react-transition-group": "^4.4.12",
     "@typescript-eslint/eslint-plugin": "^8.58.0",
     "@typescript-eslint/parser": "^8.58.0",
-    "@vitejs/plugin-react-swc": "^4.3.0",
+    "@vitejs/plugin-react": "^6.0.1",
     "@vitest/browser": "^4.1.2",
     "@vitest/browser-playwright": "^4.1.2",
     "@vitest/coverage-v8": "^4.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,9 +271,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.58.0
         version: 8.58.1(eslint@10.2.0)(typescript@6.0.2)
-      '@vitejs/plugin-react-swc':
-        specifier: ^4.3.0
-        version: 4.3.0(@swc/helpers@0.5.18)(vite@8.0.8(@types/node@25.5.2)(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.4))
+      '@vitejs/plugin-react':
+        specifier: ^6.0.1
+        version: 6.0.1(vite@8.0.8(@types/node@25.5.2)(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.4))
       '@vitest/browser':
         specifier: ^4.1.2
         version: 4.1.4(vite@8.0.8(@types/node@25.5.2)(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.4))(vitest@4.1.4)
@@ -321,7 +321,7 @@ importers:
         version: 1.59.1
       quicktype:
         specifier: ^23.2.6
-        version: 23.2.6(@swc/core@1.15.11(@swc/helpers@0.5.18))
+        version: 23.2.6
       sass-embedded:
         specifier: ^1.99.0
         version: 1.99.0
@@ -830,87 +830,8 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@swc/core-darwin-arm64@1.15.11':
-    resolution: {integrity: sha512-QoIupRWVH8AF1TgxYyeA5nS18dtqMuxNwchjBIwJo3RdwLEFiJq6onOx9JAxHtuPwUkIVuU2Xbp+jCJ7Vzmgtg==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@swc/core-darwin-x64@1.15.11':
-    resolution: {integrity: sha512-S52Gu1QtPSfBYDiejlcfp9GlN+NjTZBRRNsz8PNwBgSE626/FUf2PcllVUix7jqkoMC+t0rS8t+2/aSWlMuQtA==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@swc/core-linux-arm-gnueabihf@1.15.11':
-    resolution: {integrity: sha512-lXJs8oXo6Z4yCpimpQ8vPeCjkgoHu5NoMvmJZ8qxDyU99KVdg6KwU9H79vzrmB+HfH+dCZ7JGMqMF//f8Cfvdg==}
-    engines: {node: '>=10'}
-    cpu: [arm]
-    os: [linux]
-
-  '@swc/core-linux-arm64-gnu@1.15.11':
-    resolution: {integrity: sha512-chRsz1K52/vj8Mfq/QOugVphlKPWlMh10V99qfH41hbGvwAU6xSPd681upO4bKiOr9+mRIZZW+EfJqY42ZzRyA==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@swc/core-linux-arm64-musl@1.15.11':
-    resolution: {integrity: sha512-PYftgsTaGnfDK4m6/dty9ryK1FbLk+LosDJ/RJR2nkXGc8rd+WenXIlvHjWULiBVnS1RsjHHOXmTS4nDhe0v0w==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@swc/core-linux-x64-gnu@1.15.11':
-    resolution: {integrity: sha512-DKtnJKIHiZdARyTKiX7zdRjiDS1KihkQWatQiCHMv+zc2sfwb4Glrodx2VLOX4rsa92NLR0Sw8WLcPEMFY1szQ==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@swc/core-linux-x64-musl@1.15.11':
-    resolution: {integrity: sha512-mUjjntHj4+8WBaiDe5UwRNHuEzLjIWBTSGTw0JT9+C9/Yyuh4KQqlcEQ3ro6GkHmBGXBFpGIj/o5VMyRWfVfWw==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@swc/core-win32-arm64-msvc@1.15.11':
-    resolution: {integrity: sha512-ZkNNG5zL49YpaFzfl6fskNOSxtcZ5uOYmWBkY4wVAvgbSAQzLRVBp+xArGWh2oXlY/WgL99zQSGTv7RI5E6nzA==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@swc/core-win32-ia32-msvc@1.15.11':
-    resolution: {integrity: sha512-6XnzORkZCQzvTQ6cPrU7iaT9+i145oLwnin8JrfsLG41wl26+5cNQ2XV3zcbrnFEV6esjOceom9YO1w9mGJByw==}
-    engines: {node: '>=10'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@swc/core-win32-x64-msvc@1.15.11':
-    resolution: {integrity: sha512-IQ2n6af7XKLL6P1gIeZACskSxK8jWtoKpJWLZmdXTDj1MGzktUy4i+FvpdtxFmJWNavRWH1VmTr6kAubRDHeKw==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@swc/core@1.15.11':
-    resolution: {integrity: sha512-iLmLTodbYxU39HhMPaMUooPwO/zqJWvsqkrXv1ZI38rMb048p6N7qtAtTp37sw9NzSrvH6oli8EdDygo09IZ/w==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@swc/helpers': '>=0.5.17'
-    peerDependenciesMeta:
-      '@swc/helpers':
-        optional: true
-
-  '@swc/counter@0.1.3':
-    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
-
   '@swc/helpers@0.5.18':
     resolution: {integrity: sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==}
-
-  '@swc/types@0.1.25':
-    resolution: {integrity: sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -1172,11 +1093,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@vitejs/plugin-react-swc@4.3.0':
-    resolution: {integrity: sha512-mOkXCII839dHyAt/gpoSlm28JIVDwhZ6tnG6wJxUy2bmOx7UaPjvOyIDf3SFv5s7Eo7HVaq6kRcu6YMEzt5Z7w==}
+  '@vitejs/plugin-react@6.0.1':
+    resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: ^4 || ^5 || ^6 || ^7 || ^8
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
 
   '@vitest/browser-playwright@4.1.4':
     resolution: {integrity: sha512-q3PchVhZINX23Pv+RERgAtDlp6wzVkID/smOPnZ5YGWpeWUe3jMNYppeVh15j4il3G7JIJty1d1Kicpm0HSMig==}
@@ -4067,14 +3995,14 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@mark.probst/typescript-json-schema@0.55.0(@swc/core@1.15.11(@swc/helpers@0.5.18))':
+  '@mark.probst/typescript-json-schema@0.55.0':
     dependencies:
       '@types/json-schema': 7.0.15
       '@types/node': 16.18.126
       glob: 7.2.3
       path-equal: 1.2.5
       safe-stable-stringify: 2.5.0
-      ts-node: 10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@16.18.126)(typescript@4.9.4)
+      ts-node: 10.9.2(@types/node@16.18.126)(typescript@4.9.4)
       typescript: 4.9.4
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -4236,62 +4164,9 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@swc/core-darwin-arm64@1.15.11':
-    optional: true
-
-  '@swc/core-darwin-x64@1.15.11':
-    optional: true
-
-  '@swc/core-linux-arm-gnueabihf@1.15.11':
-    optional: true
-
-  '@swc/core-linux-arm64-gnu@1.15.11':
-    optional: true
-
-  '@swc/core-linux-arm64-musl@1.15.11':
-    optional: true
-
-  '@swc/core-linux-x64-gnu@1.15.11':
-    optional: true
-
-  '@swc/core-linux-x64-musl@1.15.11':
-    optional: true
-
-  '@swc/core-win32-arm64-msvc@1.15.11':
-    optional: true
-
-  '@swc/core-win32-ia32-msvc@1.15.11':
-    optional: true
-
-  '@swc/core-win32-x64-msvc@1.15.11':
-    optional: true
-
-  '@swc/core@1.15.11(@swc/helpers@0.5.18)':
-    dependencies:
-      '@swc/counter': 0.1.3
-      '@swc/types': 0.1.25
-    optionalDependencies:
-      '@swc/core-darwin-arm64': 1.15.11
-      '@swc/core-darwin-x64': 1.15.11
-      '@swc/core-linux-arm-gnueabihf': 1.15.11
-      '@swc/core-linux-arm64-gnu': 1.15.11
-      '@swc/core-linux-arm64-musl': 1.15.11
-      '@swc/core-linux-x64-gnu': 1.15.11
-      '@swc/core-linux-x64-musl': 1.15.11
-      '@swc/core-win32-arm64-msvc': 1.15.11
-      '@swc/core-win32-ia32-msvc': 1.15.11
-      '@swc/core-win32-x64-msvc': 1.15.11
-      '@swc/helpers': 0.5.18
-
-  '@swc/counter@0.1.3': {}
-
   '@swc/helpers@0.5.18':
     dependencies:
       tslib: 2.8.1
-
-  '@swc/types@0.1.25':
-    dependencies:
-      '@swc/counter': 0.1.3
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -4537,13 +4412,10 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitejs/plugin-react-swc@4.3.0(@swc/helpers@0.5.18)(vite@8.0.8(@types/node@25.5.2)(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.4))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.8(@types/node@25.5.2)(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.4))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      '@swc/core': 1.15.11(@swc/helpers@0.5.18)
       vite: 8.0.8(@types/node@25.5.2)(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.4)
-    transitivePeerDependencies:
-      - '@swc/helpers'
 
   '@vitest/browser-playwright@4.1.4(playwright@1.59.1)(vite@8.0.8(@types/node@25.5.2)(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.4))(vitest@4.1.4)':
     dependencies:
@@ -6506,9 +6378,9 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  quicktype-typescript-input@23.2.6(@swc/core@1.15.11(@swc/helpers@0.5.18)):
+  quicktype-typescript-input@23.2.6:
     dependencies:
-      '@mark.probst/typescript-json-schema': 0.55.0(@swc/core@1.15.11(@swc/helpers@0.5.18))
+      '@mark.probst/typescript-json-schema': 0.55.0
       quicktype-core: 23.2.6
       typescript: 4.9.5
     transitivePeerDependencies:
@@ -6516,7 +6388,7 @@ snapshots:
       - '@swc/wasm'
       - encoding
 
-  quicktype@23.2.6(@swc/core@1.15.11(@swc/helpers@0.5.18)):
+  quicktype@23.2.6:
     dependencies:
       '@glideapps/ts-necessities': 2.4.0
       chalk: 4.1.2
@@ -6529,7 +6401,7 @@ snapshots:
       moment: 2.30.1
       quicktype-core: 23.2.6
       quicktype-graphql-input: 23.2.6
-      quicktype-typescript-input: 23.2.6(@swc/core@1.15.11(@swc/helpers@0.5.18))
+      quicktype-typescript-input: 23.2.6
       readable-stream: 4.7.0
       stream-json: 1.8.0
       string-to-stream: 3.0.1
@@ -7040,7 +6912,7 @@ snapshots:
     dependencies:
       typescript: 6.0.2
 
-  ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@16.18.126)(typescript@4.9.4):
+  ts-node@10.9.2(@types/node@16.18.126)(typescript@4.9.4):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -7057,8 +6929,6 @@ snapshots:
       typescript: 4.9.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.15.11(@swc/helpers@0.5.18)
 
   tslib@2.8.1: {}
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 import { crx } from "@crxjs/vite-plugin";
-import react from "@vitejs/plugin-react-swc";
+import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import zipPack from "vite-plugin-zip-pack";
 import manifest from "./manifest.config";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,10 +11,10 @@ export default defineConfig({
     tsconfigPaths: true,
   },
   plugins: [
+    crx({ manifest }),
     react({
       jsxImportSource: "@emotion/react",
     }),
-    crx({ manifest }),
     zipPack({
       inDir: "dist",
       outDir: ".",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import react from "@vitejs/plugin-react-swc";
+import react from "@vitejs/plugin-react";
 import { playwright } from "@vitest/browser-playwright";
 import { defineConfig } from "vitest/config";
 


### PR DESCRIPTION
## Summary

Address two Vite 8 warnings emitted on `vite build` that came from plugin deprecation/compat issues, not from this project's own config.

### 1. Replace `@vitejs/plugin-react-swc` with `@vitejs/plugin-react`

`@vitejs/plugin-react-swc@4.3.0` returns `esbuild: { jsx: "automatic", ... }` from its build-apply config hook. Vite 8 deprecated the `esbuild` option in favor of `oxc`, so this triggered:

- `` `esbuild` option was specified by "vite:react-swc" plugin. ``
- `` `esbuild` option was specified by "crx:web-accessible-resources" plugin. `` (echoed via spread)

Plus the SWC plugin itself recommends migrating to `@vitejs/plugin-react` on rolldown-vite. Switched the dependency and import; `jsxImportSource: "@emotion/react"` continues to work as-is. (`vitest.config.ts` was already on `@vitejs/plugin-react`.)

### 2. Reorder `crx({ manifest })` before `react(...)`

After (1), a different warning surfaced:

- `` Both `rollupOptions` and `rolldownOptions` were specified by "crx:content-scripts" plugin. ``

Root cause is a known `@crxjs/vite-plugin` issue ([crxjs/chrome-extension-tools#1145](https://github.com/crxjs/chrome-extension-tools/issues/1145)) interacting with `@vitejs/plugin-react` v6:

- `@vitejs/plugin-react` v6's `vite:react-refresh` hook (`enforce: "pre"`) returns `build: { rollupOptions: { onwarn } }` (silenceUseClientWarning).
- Vite 8's compat layer then aliases `build.rollupOptions` and `build.rolldownOptions` to the same object.
- `@crxjs/vite-plugin`'s `crx:content-scripts` hook (`enforce: "pre"`) spreads `config.build` and overwrites `rollupOptions` with a new object, causing the two keys to diverge → warning fires and `preserveEntrySignatures: "exports-only"` is silently dropped.

Reordering plugins so `crx()` runs before `react()` makes `crx:content-scripts.config()` execute first, when `rolldownOptions` is still `undefined`, avoiding the divergence. As a side benefit, `mergeConfigRecursively`'s rollup→rolldown merge rule then preserves both `preserveEntrySignatures` and `onwarn` instead of dropping one.