### PR TITLE
Migrate dependabot to renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "npm"
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "weekly"
-    cooldown:
-      default-days: 7

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "schedule": ["* * * * 1"],
+  "minimumReleaseAge": "14 days",
+  "internalChecksFilter": "strict"
+}


### PR DESCRIPTION
## Summary

Migrate dependency update automation from Dependabot to Renovate.

### Changes

- Remove `.github/dependabot.yml`
- Add `renovate.json`

### Renovate configuration

- Base preset: `config:recommended`
- Schedule: weekly on Monday (`"* * * * 1"`)
- `minimumReleaseAge: "14 days"` — extended from Dependabot's 7-day cooldown to avoid updating to freshly released, potentially unstable versions
- `helpers:pinGitHubActionDigests` — pins GitHub Actions to their commit digest for supply chain security
- `internalChecksFilter: "strict"` — ensures dependency consistency checks pass before updates are applied