### PR TITLE
fix: replace helpers:pinDockerDigests with docker:pinDigests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": [
     "config:recommended",
     "helpers:pinGitHubActionDigests",
-    "helpers:pinDockerDigests"
+    "docker:pinDigests"
   ],
   "schedule": ["* * * * 1"],
   "minimumReleaseAge": "14 days",


### PR DESCRIPTION
## Summary

Fix an invalid Renovate preset that caused a configuration error (closes #178).

`helpers:pinDockerDigests` is not a valid Renovate preset name. It was introduced in a previous commit attempting to enable Docker image digest pinning, but caused Renovate to halt all PRs with the error:

> Cannot find preset's package (helpers:pinDockerDigests)

Replace it with the correct preset `docker:pinDigests`.