### PR TITLE
chore: pin GitHub Actions to SHA and update to latest versions

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -23,8 +23,8 @@ runs:
       run: pnpm test:unit
       shell: bash
 
-    - uses: docker/setup-buildx-action@v3
-    - uses: docker/build-push-action@v6
+    - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+    - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
       with:
         file: test/Dockerfile
         load: true
@@ -43,7 +43,7 @@ runs:
 
     - name: Upload VRT diff images
       if: failure() && steps.browser-tests.outcome == 'failure'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: vrt-diff-images
         path: .vitest-attachments/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
             *.md
             .github/**
             !.github/workflows/ci.yml
+            !.github/actions/test/action.yml
             images/**
             LICENSE
             FUNDING.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,12 @@ jobs:
         with:
           files_ignore: |
             *.md
-            .github/**
-            !.github/workflows/ci.yml
-            !.github/actions/test/action.yml
+            .github/FUNDING.yml
+            .github/workflows/release-draft.yml
+            .vscode/**
+            renovate.json
             images/**
             LICENSE
-            FUNDING.yml
 
   test:
     needs: changes


### PR DESCRIPTION
## Summary

Pin GitHub Actions to commit SHAs to mitigate supply chain attacks, and update them to the latest versions to resolve Node.js 20 deprecation warnings.

`docker/setup-buildx-action`, `docker/build-push-action`, and `actions/upload-artifact` were referenced by mutable tags (`@v3`, `@v6`, `@v4`), which can be silently rewritten to point to malicious code. This change pins each action to an immutable commit SHA with the version noted in a comment.

The versions are also bumped to their latest releases (v4.1.0, v7.2.0, v7.0.1) that satisfy Renovate's `minimumReleaseAge: 14 days` policy, switching the runtime from Node.js 20 (deprecated) to Node.js 22.

Additionally, `ci.yml` is updated to run CI when `action.yml` is modified, so future dependency updates to the action are validated automatically.
