### PR TITLE
ci: add build provenance attestation with environment gate

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -3,12 +3,16 @@ name: Create Draft Release
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -27,12 +27,19 @@ jobs:
 
       - uses: ./.github/actions/test
 
+      - name: Generate attestation
+        id: attest
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: 'block-oli_*.zip'
+
       - name: Create draft release
         run: |
           gh release create "v${VERSION}" \
             --draft \
             --title "v${VERSION}" \
             --generate-notes \
-            block-oli_*.zip
+            block-oli_*.zip \
+            "${{ steps.attest.outputs.bundle-path }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Add SLSA build provenance attestation to the release workflow, and gate the job behind a required environment approval.

`actions/attest-build-provenance` generates a signed provenance attestation for the release zip artifacts and registers it with GitHub's attestation store. The resulting bundle file is also attached as a release asset so consumers can verify artifact integrity with `gh attestation verify`.

The job is now bound to the `release` environment, which allows required reviewers to be configured in repository settings — preventing the workflow from running without explicit approval.