### PR TITLE
fix: group playwright package and Docker image updates together in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,9 +10,8 @@
   "internalChecksFilter": "strict",
   "packageRules": [
     {
-      "groupName": "playwright monorepo",
-      "matchManagers": ["dockerfile"],
-      "matchPackageNames": ["mcr.microsoft.com/playwright"]
+      "groupName": "playwright",
+      "matchPackageNames": ["playwright", "mcr.microsoft.com/playwright"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Group the `playwright` npm package and the `mcr.microsoft.com/playwright` Docker image into a single Renovate update, so they are always bumped together in one PR.

Previously, `matchManagers: ["dockerfile"]` scoped the grouping rule to the Dockerfile only, which caused Renovate to open separate PRs for the npm package and the Docker image. When the npm package was updated first, CI would fail because `test/Dockerfile` still referenced the old image version — triggering the "Executable doesn't exist" error from Playwright.

Removing the `matchManagers` filter and adding `playwright` to `matchPackageNames` makes Renovate treat both as a single dependency group. Future updates will modify `package.json`, `pnpm-lock.yaml`, and `test/Dockerfile` in one PR, keeping the versions in sync.