### PR TITLE
ci: migrate release attestation to actions/attest v4.1.1

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Generate attestation
         id: attest
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-path: 'block-oli_*.zip'
 


### PR DESCRIPTION
## Summary

Migrate the release attestation step from `actions/attest-build-provenance` to `actions/attest` v4.1.1.

As of v4, `actions/attest-build-provenance` is a thin wrapper around `actions/attest`, and the upstream README recommends using `actions/attest` directly for new implementations. When no SBOM or custom predicate is provided, `actions/attest` automatically generates a SLSA build provenance attestation — identical behavior to the previous action.