### PR TITLE
docs: add security policy for vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release is actively supported with security updates.
+
+| Version | Supported |
+| ------- | --------- |
+| latest  | ✅        |
+| older   | ❌        |
+
+## Reporting a Vulnerability
+
+Please **do not** report security vulnerabilities through public GitHub issues.
+
+Instead, use GitHub's private vulnerability reporting:
+
+**[Report a vulnerability](https://github.com/dash14/BLOCKoli/security/advisories/new)**
+
+Please include as much of the following information as possible:
+
+- Description of the vulnerability and its potential impact
+- Steps to reproduce the issue
+- Browser version and OS where the issue was observed
+- Any relevant screenshots or proof-of-concept
+
+You can expect an initial response within a few days. If the vulnerability is confirmed, a fix will be prioritized based on severity.


### PR DESCRIPTION
## Summary

Add a `SECURITY.md` file to document the project's security policy and provide a clear channel for reporting vulnerabilities.

The file specifies that only the latest release is supported, and directs reporters to GitHub's private vulnerability reporting feature rather than public issues. This keeps sensitive disclosures confidential until a fix is in place.