### PR TITLE
test: introduce fast-check for property-based testing of core modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "eslint-plugin-import-x": "^4.16.2",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
+    "fast-check": "^4.8.0",
     "globals": "^17.6.0",
     "happy-dom": "^20.9.0",
     "lodash-es": "^4.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,6 +301,9 @@ importers:
       eslint-plugin-react-refresh:
         specifier: ^0.5.2
         version: 0.5.3(eslint@10.5.0)
+      fast-check:
+        specifier: ^4.8.0
+        version: 4.8.0
       globals:
         specifier: ^17.6.0
         version: 17.6.0
@@ -1758,6 +1761,10 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  fast-check@4.8.0:
+    resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
+    engines: {node: '>=12.17.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -2456,6 +2463,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
   quicktype-core@23.2.6:
     resolution: {integrity: sha512-asfeSv7BKBNVb9WiYhFRBvBZHcRutPRBwJMxW0pefluK4kkKu4lv0IvZBwFKvw2XygLcL1Rl90zxWDHYgkwCmA==}
@@ -4996,6 +5006,10 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  fast-check@4.8.0:
+    dependencies:
+      pure-rand: 8.4.0
+
   fast-deep-equal@3.1.3: {}
 
   fast-json-stable-stringify@2.1.0: {}
@@ -5478,6 +5492,8 @@ snapshots:
       proxy-compare: 3.0.1
 
   punycode@2.3.1: {}
+
+  pure-rand@8.4.0: {}
 
   quicktype-core@23.2.6:
     dependencies:

--- a/src/modules/core/array.properties.test.ts
+++ b/src/modules/core/array.properties.test.ts
@@ -1,0 +1,188 @@
+import * as fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import { push, removeAt, replaceAt } from "./array";
+
+describe("array (property-based)", () => {
+  describe("push", () => {
+    it("does not mutate the original list", () => {
+      fc.assert(
+        fc.property(fc.array(fc.integer()), fc.integer(), (list, item) => {
+          const copy = [...list];
+          push(list, item);
+          expect(list).toEqual(copy);
+        })
+      );
+    });
+
+    it("increases length by 1", () => {
+      fc.assert(
+        fc.property(fc.array(fc.integer()), fc.integer(), (list, item) => {
+          expect(push(list, item)).toHaveLength(list.length + 1);
+        })
+      );
+    });
+
+    it("appends item at the last position", () => {
+      fc.assert(
+        fc.property(fc.array(fc.integer()), fc.integer(), (list, item) => {
+          const result = push(list, item);
+          expect(result[list.length]).toBe(item);
+        })
+      );
+    });
+
+    it("preserves all original elements in order", () => {
+      fc.assert(
+        fc.property(fc.array(fc.integer()), fc.integer(), (list, item) => {
+          expect(push(list, item).slice(0, list.length)).toEqual(list);
+        })
+      );
+    });
+  });
+
+  describe("removeAt", () => {
+    it("does not mutate the original list", () => {
+      fc.assert(
+        fc.property(
+          fc.array(fc.integer()),
+          fc.integer(),
+          (list, index) => {
+            const copy = [...list];
+            removeAt(list, index);
+            expect(list).toEqual(copy);
+          }
+        )
+      );
+    });
+
+    it("decreases length by 1 for a valid index", () => {
+      fc.assert(
+        fc.property(
+          fc.array(fc.integer(), { minLength: 1 }),
+          fc.nat(),
+          (list, offset) => {
+            const index = offset % list.length;
+            expect(removeAt(list, index)).toHaveLength(list.length - 1);
+          }
+        )
+      );
+    });
+
+    it("preserves length for an out-of-bounds index", () => {
+      fc.assert(
+        fc.property(
+          fc.array(fc.integer()).chain((list) =>
+            fc.tuple(
+              fc.constant(list),
+              fc.oneof(
+                fc.integer({ max: -1 }),
+                fc.nat().map((n) => list.length + n)
+              )
+            )
+          ),
+          ([list, index]) => {
+            expect(removeAt(list, index)).toHaveLength(list.length);
+          }
+        )
+      );
+    });
+
+    it("removes exactly the element at the specified valid index", () => {
+      fc.assert(
+        fc.property(
+          fc.array(fc.integer(), { minLength: 1 }),
+          fc.nat(),
+          (list, offset) => {
+            const index = offset % list.length;
+            const result = removeAt(list, index);
+            const expected = [...list.slice(0, index), ...list.slice(index + 1)];
+            expect(result).toEqual(expected);
+          }
+        )
+      );
+    });
+  });
+
+  describe("replaceAt", () => {
+    it("does not mutate the original list", () => {
+      fc.assert(
+        fc.property(
+          fc.array(fc.integer()),
+          fc.integer(),
+          fc.integer(),
+          (list, index, item) => {
+            const copy = [...list];
+            replaceAt(list, index, item);
+            expect(list).toEqual(copy);
+          }
+        )
+      );
+    });
+
+    it("always preserves length", () => {
+      fc.assert(
+        fc.property(
+          fc.array(fc.integer()),
+          fc.integer(),
+          fc.integer(),
+          (list, index, item) => {
+            expect(replaceAt(list, index, item)).toHaveLength(list.length);
+          }
+        )
+      );
+    });
+
+    it("replaces the element at a valid index", () => {
+      fc.assert(
+        fc.property(
+          fc.array(fc.integer(), { minLength: 1 }),
+          fc.nat(),
+          fc.integer(),
+          (list, offset, item) => {
+            const index = offset % list.length;
+            expect(replaceAt(list, index, item)[index]).toBe(item);
+          }
+        )
+      );
+    });
+
+    it("leaves all other elements unchanged at a valid index", () => {
+      fc.assert(
+        fc.property(
+          fc.array(fc.integer(), { minLength: 1 }),
+          fc.nat(),
+          fc.integer(),
+          (list, offset, item) => {
+            const index = offset % list.length;
+            const result = replaceAt(list, index, item);
+            for (let i = 0; i < list.length; i++) {
+              if (i !== index) {
+                expect(result[i]).toBe(list[i]);
+              }
+            }
+          }
+        )
+      );
+    });
+
+    it("returns the original list unchanged for an out-of-bounds index", () => {
+      fc.assert(
+        fc.property(
+          fc.array(fc.integer()).chain((list) =>
+            fc.tuple(
+              fc.constant(list),
+              fc.oneof(
+                fc.integer({ max: -1 }),
+                fc.nat().map((n) => list.length + n)
+              ),
+              fc.integer()
+            )
+          ),
+          ([list, index, item]) => {
+            expect(replaceAt(list, index, item)).toEqual(list);
+          }
+        )
+      );
+    });
+  });
+});

--- a/src/modules/rules/convert.properties.test.ts
+++ b/src/modules/rules/convert.properties.test.ts
@@ -1,0 +1,179 @@
+import * as fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import {
+  REQUEST_METHODS,
+  RESOURCE_TYPES,
+  RuleActionType,
+  type RequestMethod,
+  type ResourceType,
+} from "@/modules/core/rules";
+import { convertToApiRule } from "./convert";
+import type { StoredRule } from "./stored";
+
+const actionTypeArb = fc.constantFrom(
+  RuleActionType.BLOCK,
+  RuleActionType.ALLOW
+);
+
+const requestMethodArb = fc.constantFrom(
+  ...(REQUEST_METHODS as [RequestMethod, ...RequestMethod[]])
+);
+
+const resourceTypeArb = fc.constantFrom(
+  ...(RESOURCE_TYPES as [ResourceType, ...ResourceType[]])
+);
+
+const domainArb = fc.domain();
+
+const storedRuleArb: fc.Arbitrary<StoredRule> = fc.record({
+  id: fc.integer({ min: 1 }),
+  action: fc.record({ type: actionTypeArb }),
+  condition: fc.record(
+    {
+      requestDomains: fc.option(fc.array(domainArb), { nil: undefined }),
+      initiatorDomains: fc.option(fc.array(domainArb), { nil: undefined }),
+      urlFilter: fc.option(fc.string({ minLength: 1 }), { nil: undefined }),
+      isRegexFilter: fc.option(fc.boolean(), { nil: undefined }),
+      requestMethods: fc.option(fc.array(requestMethodArb), { nil: undefined }),
+      resourceTypes: fc.option(fc.array(resourceTypeArb), { nil: undefined }),
+    },
+    { requiredKeys: [] }
+  ),
+});
+
+describe("convertToApiRule (property-based)", () => {
+  it("preserves the number of rules", () => {
+    fc.assert(
+      fc.property(fc.array(storedRuleArb), (rules) => {
+        expect(convertToApiRule(rules)).toHaveLength(rules.length);
+      })
+    );
+  });
+
+  it("resourceTypes is always defined and non-empty", () => {
+    fc.assert(
+      fc.property(fc.array(storedRuleArb), (rules) => {
+        const result = convertToApiRule(rules);
+        for (const apiRule of result) {
+          expect(apiRule.condition.resourceTypes).toBeDefined();
+          expect(apiRule.condition.resourceTypes!.length).toBeGreaterThan(0);
+        }
+      })
+    );
+  });
+
+  it("empty or undefined resourceTypes is expanded to all RESOURCE_TYPES", () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          storedRuleArb.map((rule) => ({
+            ...rule,
+            condition: { ...rule.condition, resourceTypes: undefined },
+          }))
+        ),
+        (rules) => {
+          const result = convertToApiRule(rules);
+          for (const apiRule of result) {
+            expect(apiRule.condition.resourceTypes).toEqual(RESOURCE_TYPES);
+          }
+        }
+      )
+    );
+  });
+
+  it("empty requestDomains, initiatorDomains, and requestMethods arrays are omitted from the API rule", () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          storedRuleArb.map((rule) => ({
+            ...rule,
+            condition: {
+              ...rule.condition,
+              requestDomains: [],
+              initiatorDomains: [],
+              requestMethods: [],
+            },
+          }))
+        ),
+        (rules) => {
+          const result = convertToApiRule(rules);
+          for (const apiRule of result) {
+            expect(apiRule.condition.requestDomains).toBeUndefined();
+            expect(apiRule.condition.initiatorDomains).toBeUndefined();
+            expect(apiRule.condition.requestMethods).toBeUndefined();
+          }
+        }
+      )
+    );
+  });
+
+  it("urlFilter and regexFilter are never both set", () => {
+    fc.assert(
+      fc.property(fc.array(storedRuleArb), (rules) => {
+        const result = convertToApiRule(rules);
+        for (const apiRule of result) {
+          const bothSet =
+            apiRule.condition.urlFilter !== undefined &&
+            apiRule.condition.regexFilter !== undefined;
+          expect(bothSet).toBe(false);
+        }
+      })
+    );
+  });
+
+  it("urlFilter with isRegexFilter=true is mapped to regexFilter", () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          storedRuleArb.map((rule) => ({
+            ...rule,
+            condition: {
+              ...rule.condition,
+              urlFilter: rule.condition.urlFilter ?? "example",
+              isRegexFilter: true,
+            },
+          }))
+        ),
+        (rules) => {
+          const result = convertToApiRule(rules);
+          for (let i = 0; i < result.length; i++) {
+            expect(result[i].condition.regexFilter).toBe(
+              rules[i].condition.urlFilter
+            );
+            expect(result[i].condition.urlFilter).toBeUndefined();
+          }
+        }
+      )
+    );
+  });
+
+  it("urlFilter with isRegexFilter=false/undefined is kept as urlFilter", () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          storedRuleArb.chain((rule) =>
+            fc
+              .constantFrom(false as false | undefined, undefined)
+              .map((isRegexFilter) => ({
+                ...rule,
+                condition: {
+                  ...rule.condition,
+                  urlFilter: rule.condition.urlFilter ?? "example",
+                  isRegexFilter,
+                },
+              }))
+          )
+        ),
+        (rules) => {
+          const result = convertToApiRule(rules);
+          for (let i = 0; i < result.length; i++) {
+            expect(result[i].condition.urlFilter).toBe(
+              rules[i].condition.urlFilter
+            );
+            expect(result[i].condition.regexFilter).toBeUndefined();
+          }
+        }
+      )
+    );
+  });
+});

--- a/src/modules/utils/unique.properties.test.ts
+++ b/src/modules/utils/unique.properties.test.ts
@@ -1,0 +1,123 @@
+import * as fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import { unique, uniqueObjects } from "./unique";
+
+describe("unique (property-based)", () => {
+  describe("unique", () => {
+    // Use a small range to ensure duplicates are reliably generated
+    const intArb = fc.integer({ min: 0, max: 10 });
+
+    it("is idempotent", () => {
+      fc.assert(
+        fc.property(fc.array(intArb), (list) => {
+          const once = unique(list);
+          expect(unique(once)).toEqual(once);
+        })
+      );
+    });
+
+    it("result is a subset of the input (length)", () => {
+      fc.assert(
+        fc.property(fc.array(intArb), (list) => {
+          expect(unique(list).length).toBeLessThanOrEqual(list.length);
+        })
+      );
+    });
+
+    it("contains all elements from the input", () => {
+      fc.assert(
+        fc.property(fc.array(intArb), (list) => {
+          const resultSet = new Set(unique(list));
+          for (const item of list) {
+            expect(resultSet.has(item)).toBe(true);
+          }
+        })
+      );
+    });
+
+    it("has no duplicate elements", () => {
+      fc.assert(
+        fc.property(fc.array(intArb), (list) => {
+          const result = unique(list);
+          expect(new Set(result).size).toBe(result.length);
+        })
+      );
+    });
+
+    it("preserves the order of first occurrences", () => {
+      fc.assert(
+        fc.property(fc.array(intArb), (list) => {
+          const result = unique(list);
+          // Verify each result element's position matches its first occurrence in the input
+          const firstOccurrenceIndices = result.map((item) =>
+            list.indexOf(item)
+          );
+          for (let i = 1; i < firstOccurrenceIndices.length; i++) {
+            expect(firstOccurrenceIndices[i]).toBeGreaterThan(
+              firstOccurrenceIndices[i - 1]
+            );
+          }
+        })
+      );
+    });
+  });
+
+  describe("uniqueObjects", () => {
+    it("is idempotent", () => {
+      fc.assert(
+        fc.property(fc.array(fc.jsonValue()), (list) => {
+          expect(uniqueObjects(uniqueObjects(list))).toEqual(uniqueObjects(list));
+        })
+      );
+    });
+
+    it("result is a subset of the input (length)", () => {
+      fc.assert(
+        fc.property(fc.array(fc.jsonValue()), (list) => {
+          expect(uniqueObjects(list).length).toBeLessThanOrEqual(list.length);
+        })
+      );
+    });
+
+    it("contains all distinct JSON-serializable elements from the input", () => {
+      fc.assert(
+        fc.property(fc.array(fc.jsonValue()), (list) => {
+          const result = uniqueObjects(list);
+          for (const item of list) {
+            const key = JSON.stringify(item);
+            expect(result.some((r) => JSON.stringify(r) === key)).toBe(true);
+          }
+        })
+      );
+    });
+
+    it("has no duplicate elements (by JSON.stringify)", () => {
+      fc.assert(
+        fc.property(fc.array(fc.jsonValue()), (list) => {
+          const result = uniqueObjects(list);
+          const keys = result.map((v) => JSON.stringify(v));
+          expect(new Set(keys).size).toBe(keys.length);
+        })
+      );
+    });
+
+    it("preserves the order of first occurrences", () => {
+      fc.assert(
+        fc.property(fc.array(fc.jsonValue()), (list) => {
+          const result = uniqueObjects(list);
+          // Each result element must be the first occurrence in the input with that key,
+          // and those first-occurrence positions must be strictly increasing.
+          const firstOccurrenceIndices = result.map((item) => {
+            const key = JSON.stringify(item);
+            return list.findIndex((v) => JSON.stringify(v) === key);
+          });
+          for (let i = 1; i < firstOccurrenceIndices.length; i++) {
+            expect(firstOccurrenceIndices[i]).toBeGreaterThan(
+              firstOccurrenceIndices[i - 1]
+            );
+          }
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Introduce property-based testing with fast-check for the core pure-function modules.

Three test files are added alongside their existing unit tests, each named `*.properties.test.ts` to make the test type explicit:

- `src/modules/core/array.properties.test.ts` — covers `push`, `removeAt`, and `replaceAt` with properties such as immutability, length invariants, and correct behavior at valid vs. out-of-bounds indices.
- `src/modules/utils/unique.properties.test.ts` — covers `unique` and `uniqueObjects` with properties such as idempotency, subset length, containment, no-duplicates, and order preservation.
- `src/modules/rules/convert.properties.test.ts` — covers `convertToApiRule` with properties such as output length, guaranteed `resourceTypes` expansion, empty-array field suppression via `emptyToUndefined`, and mutual exclusivity of `urlFilter` and `regexFilter`.

fast-check generates hundreds of randomized inputs per property on each run, exercising edge cases — such as empty arrays, boundary indices, and all combinations of `isRegexFilter` — that are impractical to enumerate manually.