### PR TITLE
ci: cache pnpm store in Docker build using BuildKit cache mount

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -14,6 +14,7 @@ runs:
 
     - run: pnpm install --frozen-lockfile
       shell: bash
+
     - run: pnpm lint
       shell: bash
     - run: pnpm build

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,6 +1,10 @@
 FROM mcr.microsoft.com/playwright:v1.61.0-noble@sha256:57b65fdc9ceabe0ef613124c7bbe2babcf9362c4d85e382fe3b03604e84b428a
 
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
-RUN corepack enable
 
 WORKDIR /app
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
+    corepack enable && \
+    pnpm install --frozen-lockfile --config.updateNotifier=false


### PR DESCRIPTION
## Summary

Speed up the Docker-based browser test step by caching the pnpm store across CI runs via BuildKit's `--mount=type=cache`, backed by GitHub Actions cache storage.