### PR TITLE
ci: write docker build cache only on the default branch

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -25,13 +25,14 @@ runs:
       shell: bash
 
     - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
     - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
       with:
         file: test/Dockerfile
         load: true
         tags: test-test:latest
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: ${{ github.ref_name != github.event.repository.default_branch && 'type=gha' || '' }}
+        cache-to: ${{ github.ref_name == github.event.repository.default_branch && 'type=gha,mode=max' || '' }}
       env:
         DOCKER_BUILD_CHECKS_ANNOTATIONS: 'false'
         DOCKER_BUILD_SUMMARY: 'false'


### PR DESCRIPTION
## Summary

Scope the Docker build's GitHub Actions cache (`type=gha`) so that only the default branch writes to it (`cache-to`), while all other branches only read from it (`cache-from`).

Previously, every branch both read and wrote the cache. Feature-branch builds could overwrite the shared cache with branch-specific layers, degrading cache hits for other branches and the default branch alike.