### PR TITLE
ci: name release attestation *.sigstore.json and pin zip asset name to $VERSION

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -35,7 +35,11 @@ jobs:
         id: attest
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
-          subject-path: 'block-oli_*.zip'
+          subject-path: 'block-oli_${{ env.VERSION }}.zip'
+
+      - name: Rename attestation bundle
+        run: |
+          cp "${{ steps.attest.outputs.bundle-path }}" "block-oli_${VERSION}.zip.sigstore.json"
 
       - name: Create draft release
         run: |
@@ -43,7 +47,7 @@ jobs:
             --draft \
             --title "v${VERSION}" \
             --generate-notes \
-            block-oli_*.zip \
-            "${{ steps.attest.outputs.bundle-path }}"
+            "block-oli_${VERSION}.zip" \
+            "block-oli_${VERSION}.zip.sigstore.json"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Rename the release attestation asset from the raw `bundle-path` output filename to `block-oli_$VERSION.zip.sigstore.json`, matching the actual content it contains: a JSON-serialized Sigstore bundle (as documented by `actions/attest`), not the `*.intoto.jsonl` DSSE-envelope format some tooling expects. `.sigstore.json` is the convention Sigstore tooling (e.g. cosign) uses for this format.

Also unify how the release zip is referenced across steps. The `block-oli_*.zip` wildcard glob is unnecessary since `vite-plugin-zip-pack` produces a deterministic filename (`${pkg.name}_${pkg.version}.zip`), so every step now names it explicitly via `$VERSION`, matching the attestation asset's naming.